### PR TITLE
Add null check to `Intent.getStringExtra()`

### DIFF
--- a/android/src/main/kotlin/com/drenther/upi_pay/UpiPayPlugin.kt
+++ b/android/src/main/kotlin/com/drenther/upi_pay/UpiPayPlugin.kt
@@ -151,7 +151,7 @@ class UpiPayPlugin internal constructor(registrar: Registrar, channel: MethodCha
         if (requestCodeNumber == requestCode && result != null) {
             if (data != null) {
                 try {
-                    val response = data.getStringExtra("response")
+                    val response = data.getStringExtra("response")!!
                     this.success(response)
                 } catch (ex: Exception) {
                     this.success("invalid_response")


### PR DESCRIPTION
Add Null Check
The `Intent.getStringExtra()` method returns a nullable String.
Fixes #20 