### PR TITLE
Added playstore option in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,7 @@ If applicable, add screenshots to help explain your problem.
 - Device: [e.g. OnePlus Nord]
 - Package Version: [e.g. v1.0.0]
 - UPI Applications in the device: [e.g. - GPay, Paytm]
+- Play Store: [e.g. Google, Mi, Vivo]
 - Other UPI / Payment packages used in the app: [e.g. - razorpay_flutter]
 
 ### Additional context


### PR DESCRIPTION
### Changes in this PR:

Added play store type as a field in bug report template.

### Motive / Approach

Some of the apps like MiPay have different package IDs in different play stores. Point of this field is to identify which app (in such cases) are we talking about for an issue.

### Reference GitHub Issues:

https://github.com/drenther/upi_pay/issues/13

### Related Screenshots:

N/A
