### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.drenther.upi_pay'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Solves the following error : The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.

### Changes in this PR:

- Fix for Error : The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.

### Motive / Approach

The gradle version used in the plugin is outdated, so this change keeps the plugin up to date.
